### PR TITLE
Can now do very basic arg inference

### DIFF
--- a/spec/fake_resources.rb
+++ b/spec/fake_resources.rb
@@ -24,12 +24,15 @@ module FakeResources::Post
   end
 
   class Record
+    def initialize(params)
+    end
+
     def title
       "first post"
     end
 
     def self.find_by_id(id)
-      records = {5 => Record.new}
+      records = {5 => Record.new({})}
       records.fetch(id)
     end
   end

--- a/spec/infers_args_spec.rb
+++ b/spec/infers_args_spec.rb
@@ -1,0 +1,13 @@
+require './spec/spec_helper'
+
+describe Raptor::InfersArgs do
+  it "infers for required params for delegate methods" do
+    Raptor::InfersArgs.for(stub(:path_info => 'posts/5'), stub(:parameters => [[:req, :id]]), stub(:extract_args => {:id => 5})).must_equal [5]
+  end
+
+  it "infers [] when the method only takes optional parameters" do
+    Raptor::InfersArgs.for(stub, stub(:parameters => [[:rest]]), stub).must_equal []
+  end
+end
+
+

--- a/spec/infers_args_spec.rb
+++ b/spec/infers_args_spec.rb
@@ -1,8 +1,13 @@
 require './spec/spec_helper'
 
 describe Raptor::InfersArgs do
-  it "infers for required params for delegate methods" do
-    Raptor::InfersArgs.for(stub(:path_info => 'posts/5'), stub(:parameters => [[:req, :id]]), stub(:extract_args => {:id => 5})).must_equal [5]
+  it "infers required arguments for delegate methods" do
+    Raptor::InfersArgs.for(stub(:path_info => 'post/5', :params => stub), stub(:parameters => [[:req, :id]]), stub(:extract_args => {:id => 5})).must_equal [5]
+  end
+
+  it "infers :params" do
+    params = {'params' => 'hash'}
+    Raptor::InfersArgs.for(stub(:path_info => 'post/new', :params => params), stub(:parameters => [[:req, :params]]), stub(:extract_args => {})).must_equal [params]
   end
 
   it "infers [] when the method only takes optional parameters" do

--- a/spec/route_path_spec.rb
+++ b/spec/route_path_spec.rb
@@ -25,7 +25,7 @@ describe Raptor::RoutePath do
 
   describe "pulling the args out of a route spec and an incoming path" do
     it "pulls out args that match with keywords" do
-      Raptor::RoutePath.new('/post/:id').extract_args('/post/5').must_equal [5]
+      Raptor::RoutePath.new('/post/:id').extract_args('/post/5').must_equal({:id => 5})
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,6 @@ require 'raptor'
 require 'fake_resources'
 
 def request(path)
-  Rack::Request.new('PATH_INFO' => path)
+  Rack::Request.new('PATH_INFO' => path, 'rack.input' => {})
 end
 


### PR DESCRIPTION
If you have a path like 'post/:id', an incoming path of 'post/5' and a delegate_method that has parameters [[:req, :id]], then the router now figures out that you want the :id argument from the path.
