### PR TITLE
Add a gemspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /statistics.csv
 /statistics.numbers
 
+*.gem

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source :rubygems
 
-gem "rack"
-
-group :test do
-  gem "rspec"
-end
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: .
+  specs:
+    raptor (0.0.1)
+      rack
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -16,5 +22,5 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rack
+  raptor!
   rspec

--- a/raptor.gemspec
+++ b/raptor.gemspec
@@ -1,0 +1,18 @@
+Gem::Specification.new do |s|
+  s.name = "raptor"
+  s.version = "0.0.1"
+
+  s.authors = ["Gary Bernhardt, Tom Crayford"]
+  s.email = ["email@here.com"]
+  s.files = Dir.glob("lib/**/*") + ["README.md"]
+  s.homepage = %q{https://github.com/garybernhardt/raptor}
+  s.require_paths = ["lib"]
+  s.summary = "Raptor"
+  s.description = "Raptor"
+
+  s.add_development_dependency "rspec"
+  s.add_dependency "rack"
+
+  s.require_path = "lib"
+  s.required_rubygems_version = ">= 1.3.6"
+end


### PR DESCRIPTION
This adds a gemspec and makes Bundler look at it rather than Gemfile for dependencies. It'll need to happen eventually and having it there now lets me build apps that target raptor by putting something like this in my gemfile:

``` @ruby
gem 'raptor', path: /path/to/raptor
```

The specific details in the gemspec will need changing obviously; I've just pre-filled them with values which seemed sensible.
