### PR TITLE
Fix specs to run with 1.9.3

### DIFF
--- a/spec/delegation_spec.rb
+++ b/spec/delegation_spec.rb
@@ -4,8 +4,6 @@ require_relative "../lib/raptor/delegation"
 require_relative "../lib/raptor/injector"
 
 describe Raptor::DelegateFinder do
-  include Raptor
-
   module AModule
     module Child
       def self.a_method
@@ -14,12 +12,12 @@ describe Raptor::DelegateFinder do
   end
 
   it "finds constants in the module" do
-    method = DelegateFinder.new("AModule::Child.a_method").find
+    method = Raptor::DelegateFinder.new("AModule::Child.a_method").find
     method.should == AModule::Child.method(:a_method)
   end
 
   it "finds constants not in the module" do
-    method = DelegateFinder.new("Object.new").find
+    method = Raptor::DelegateFinder.new("Object.new").find
     method.should == Object.method(:new)
   end
 end

--- a/spec/injector_spec.rb
+++ b/spec/injector_spec.rb
@@ -3,7 +3,6 @@ require_relative "spec_helper"
 require_relative "../lib/raptor/injector"
 
 describe Raptor::Injector do
-  include Raptor
 
   def method_taking_id(id); id; end
   def method_taking_params(params); params; end
@@ -14,7 +13,7 @@ describe Raptor::Injector do
 
   let(:params) { stub }
   let(:sources) { {:params => params, :id => 5} }
-  let(:injector) { Injector.new(sources) }
+  let(:injector) { Raptor::Injector.new(sources) }
 
   it "injects required arguments for delegate methods" do
     injector.call(method(:method_taking_id)).should == 5

--- a/spec/requirements_spec.rb
+++ b/spec/requirements_spec.rb
@@ -3,38 +3,34 @@ require_relative "spec_helper"
 require_relative "../lib/raptor/router"
 
 describe Raptor::HttpMethodRequirement do
-  include Raptor
-
   it "matches when the method matches" do
-    HttpMethodRequirement.new("GET").match?("GET").should be_true
+    Raptor::HttpMethodRequirement.new("GET").match?("GET").should be_true
   end
 
   it "doesn't match when the method doesn't" do
-    HttpMethodRequirement.new("GET").match?("POST").should be_false
+    Raptor::HttpMethodRequirement.new("GET").match?("POST").should be_false
   end
 end
 
 describe Raptor::PathRequirement do
-  include Raptor
-
   it "matches exact paths" do
-    PathRequirement.new("/posts").match?("/posts").should be_true
+    Raptor::PathRequirement.new("/posts").match?("/posts").should be_true
   end
 
   it "matches variables" do
-    PathRequirement.new("/posts/:id").match?("/posts/5").should be_true
+    Raptor::PathRequirement.new("/posts/:id").match?("/posts/5").should be_true
   end
 
   it "doesn't match when the paths have different components" do
-    PathRequirement.new("/posts").match?("/users").should be_false
+    Raptor::PathRequirement.new("/posts").match?("/users").should be_false
   end
 
   it "doesn't match when the route has more components" do
-    PathRequirement.new("/posts/:id").match?("/posts").should be_false
+    Raptor::PathRequirement.new("/posts/:id").match?("/posts").should be_false
   end
 
   it "doesn't match when the route has fewer components" do
-    PathRequirement.new("/posts").match?("/posts/5").should be_false
+    Raptor::PathRequirement.new("/posts").match?("/posts/5").should be_false
   end
 end
 

--- a/spec/responders_spec.rb
+++ b/spec/responders_spec.rb
@@ -35,15 +35,13 @@ describe Raptor::RedirectResponder do
 end
 
 describe Raptor::ActionTemplateResponder do
-  include Raptor
-
   it "renders templates" do
     resource = stub(:path_component => "posts",
                     :one_presenter => APresenter)
-    responder = ActionTemplateResponder.new(resource, :one, :show)
+    responder = Raptor::ActionTemplateResponder.new(resource, :one, :show)
     record = stub
-    injector = Injector.new({})
-    Template.stub(:render).with(APresenter.new, "posts/show.html.erb").
+    injector = Raptor::Injector.new({})
+    Raptor::Template.stub(:render).with(APresenter.new, "posts/show.html.erb").
       and_return("it worked")
     response = responder.respond(record, injector)
     response.body.join.strip.should == "it worked"

--- a/spec/route_options_spec.rb
+++ b/spec/route_options_spec.rb
@@ -4,12 +4,10 @@ require_relative "../lib/raptor/router"
 require_relative "../lib/raptor/responders"
 
 describe Raptor::RouteOptions do
-  include Raptor
-
   let(:resource) { stub("resource") }
 
   it "knows actions for exceptions" do
-    options = RouteOptions.new(resource,
+    options = Raptor::RouteOptions.new(resource,
                                :redirect => :show,
                                IndexError => :index)
     options.exception_actions.should == {IndexError => :index}
@@ -23,32 +21,32 @@ describe Raptor::RouteOptions do
     it "creates responders for action templates" do
       responder = stub
       action = :show
-      ActionTemplateResponder.stub(:new).
+      Raptor::ActionTemplateResponder.stub(:new).
         with(resource, :one, action).
         and_return(responder)
-      options = RouteOptions.new(resource, {:present => :one})
+      options = Raptor::RouteOptions.new(resource, {:present => :one})
       options.responder_for(:show).should == responder
     end
 
     it "renders the action's template by default" do
       template_responder = stub
-      ActionTemplateResponder.stub(:new).with(resource, :one, :show).
+      Raptor::ActionTemplateResponder.stub(:new).with(resource, :one, :show).
         and_return(template_responder)
-      options = RouteOptions.new(resource, :present => :one)
+      options = Raptor::RouteOptions.new(resource, :present => :one)
       options.responder_for(:show).should == template_responder
     end
 
     it "uses the explicit template if one is given" do
       template_responder = stub
-      TemplateResponder.stub(:new).with(resource, :one, "show").
+      Raptor::TemplateResponder.stub(:new).with(resource, :one, "show").
         and_return(template_responder)
-      options = RouteOptions.new(resource, :present => :one, :render => "show")
+      options = Raptor::RouteOptions.new(resource, :present => :one, :render => "show")
       options.responder_for(:show).should == template_responder
     end
   end
 
   it "delegates to nothing when there's no :to" do
-    options = RouteOptions.new(resource, {})
+    options = Raptor::RouteOptions.new(resource, {})
     options.delegate_name.should == "Raptor::NullDelegate.do_nothing"
   end
 end

--- a/spec/route_spec.rb
+++ b/spec/route_spec.rb
@@ -160,11 +160,11 @@ describe Raptor::Router do
       end
 
       before do
-        Record.stub(:create) { bob }
+        FakeResources::WithNoBehavior::Record.stub(:create) { bob }
       end
 
       it "creates records" do
-        Record.should_receive(:create)
+        FakeResources::WithNoBehavior::Record.should_receive(:create)
         routes.call(req)
       end
 
@@ -175,7 +175,7 @@ describe Raptor::Router do
       end
 
       it "re-renders new on errors" do
-        Record.stub(:create).and_raise(Raptor::ValidationError)
+        FakeResources::WithNoBehavior::Record.stub(:create).and_raise(Raptor::ValidationError)
         response = routes.call(req)
         response.body.join('').strip.should == "<form>New</form>"
       end
@@ -196,11 +196,11 @@ describe Raptor::Router do
       end
 
       before do
-        Record.stub(:find_and_update) { bob }
+        FakeResources::WithNoBehavior::Record.stub(:find_and_update) { bob }
       end
 
       it "updates records" do
-        Record.should_receive(:find_and_update)
+        FakeResources::WithNoBehavior::Record.should_receive(:find_and_update)
         routes.call(req)
       end
 
@@ -211,7 +211,7 @@ describe Raptor::Router do
       end
 
       it "re-renders edit on failure" do
-        Record.stub(:find_and_update).and_raise(Raptor::ValidationError)
+        FakeResources::WithNoBehavior::Record.stub(:find_and_update).and_raise(Raptor::ValidationError)
         response = routes.call(req)
         response.body.join('').strip.should == "<form>Edit</form>"
       end
@@ -221,12 +221,12 @@ describe Raptor::Router do
       let(:req) { request('DELETE', '/with_no_behavior/7', StringIO.new('')) }
 
       it "destroys records" do
-        Record.should_receive(:destroy)
+       FakeResources::WithNoBehavior::Record.should_receive(:destroy)
         routes.call(req)
       end
 
       it "redirects to index" do
-        Record.stub(:destroy)
+        FakeResources::WithNoBehavior::Record.stub(:destroy)
         response = routes.call(req)
         response.status.should == 302
         response['Location'].should == "/with_no_behavior"

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -3,21 +3,19 @@ require_relative "spec_helper"
 require_relative "../lib/raptor/responders"
 
 describe Raptor::Template do
-  include Raptor
-
   it "raises an error when templates access undefined methods" do
     presenter = Object.new
     File.stub(:new) { StringIO.new("<% undefined_method %>") }
 
     expect do
-      Template.render(presenter, "posts/show.html.erb").render
+      Raptor::Template.render(presenter, "posts/show.html.erb").render
     end.to raise_error(NameError,
                        /undefined local variable or method `undefined_method'/)
   end
 
   it "renders the template" do
     presenter = stub("presenter")
-    rendered = Template.render(presenter, "with_no_behavior/new.html.erb")
+    rendered = Raptor::Template.render(presenter, "with_no_behavior/new.html.erb")
     rendered.strip.should == "<form>New</form>"
   end
 end


### PR DESCRIPTION
Since it seemed like the resolution of [this issue](https://github.com/garybernhardt/raptor/issues/17) was that it was a bug in 1.9.2, I decided to try to fix the specs in 1.9.3 by removing the includes and instead calling the classes via their namespaces. The route_spec is still failing though, and I couldn't really understand why. Maybe someone who understands the way it wires up could add that patch.
