### PR TITLE
rename record to subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ module MyApp
 
   module Presenters
     class Article
-      def initialize(record); @record = record; end
-      def slug; @record.title.to_slug; end
+      def initialize(subject); @subject = subject; end
+      def slug; @subject.title.to_slug; end
     end
   end
 end
@@ -101,7 +101,7 @@ There's no autoloader and no discovery of your code: you explicitly require your
 
 ## Complex behavior and the injector
 
-Any method that Raptor calls will be injected: records, presenters, requirements, even other injectables. Injection is purely name-based: if you have a method named `request`, it will get the Rack request as an argument. It's your job not to ask for HTTP data in deep layers of your application, like records (unless you really want to, in which case you can, but you should at least feel guilty about it).
+Any method that Raptor calls will be injected: subjects, presenters, requirements, even other injectables. Injection is purely name-based: if you have a method named `request`, it will get the Rack request as an argument. It's your job not to ask for HTTP data in deep layers of your application, like records (unless you really want to, in which case you can, but you should at least feel guilty about it).
 
 Injection is how form parameters are handled, for example. If your route delegates to `PostCreator.create(params)`, Raptor will automatically inject the request params as an argument. You can do the stuff you'd do in a Rails controller without hard coupling yourself to an ActionController::Base class. The reduced coupling makes testing easy and allows reuse (anyone who needs to create a post can use PostCreator!)
 

--- a/example/posts.rb
+++ b/example/posts.rb
@@ -3,9 +3,9 @@ require_relative 'fake_record'
 module Blog
   module Presenters
     class Post
-      takes :record
-      let(:id) { p @record; @record.id }
-      let(:title) { @record.title }
+      takes :subject
+      let(:id) { p @subject; @subject.id }
+      let(:title) { @subject.title }
     end
 
     class PostList

--- a/lib/raptor/injector.rb
+++ b/lib/raptor/injector.rb
@@ -43,9 +43,9 @@ module Raptor
       end
     end
 
-    def add_record(record)
+    def add_subject(subject)
       Injector.new(@injectables +
-                   [Raptor::Injectables::Fixed.new(:record, record)])
+                   [Raptor::Injectables::Fixed.new(:subject, subject)])
     end
 
     def add_request(request)

--- a/lib/raptor/responders.rb
+++ b/lib/raptor/responders.rb
@@ -6,7 +6,7 @@ module Raptor
       @text = text
     end
 
-    def respond(route, record, injector)
+    def respond(route, subject, injector)
       Rack::Response.new(@text)
     end
   end
@@ -17,13 +17,13 @@ module Raptor
       @target_route_name = target_route_name
     end
 
-    def respond(route, record, injector)
+    def respond(route, subject, injector)
       response = Rack::Response.new
       path = route.neighbor_named(@target_route_name).path
-      if record
+      if subject
         path = path.gsub(/:\w+/) do |match|
           # XXX: Untrusted send
-          record.send(match.sub(/^:/, '')).to_s
+          subject.send(match.sub(/^:/, '')).to_s
         end
       end
       redirect_to(response, path)
@@ -50,8 +50,8 @@ module Raptor
       @template_path = template_path
     end
 
-    def respond(route, record, injector)
-      presenter = create_presenter(record, injector)
+    def respond(route, subject, injector)
+      presenter = create_presenter(subject, injector)
       Rack::Response.new(render(presenter))
     end
 
@@ -63,8 +63,8 @@ module Raptor
       "#{@template_path}.html.erb"
     end
 
-    def create_presenter(record, injector)
-      injector = injector.add_record(record)
+    def create_presenter(subject, injector)
+      injector = injector.add_subject(subject)
       injector.call(presenter_class.method(:new))
     end
 
@@ -82,11 +82,11 @@ module Raptor
       @template_name = template_name
     end
 
-    def respond(route, record, injector)
+    def respond(route, subject, injector)
       responder = TemplateResponder.new(@app_module,
                                         @presenter_name,
                                         template_path)
-      responder.respond(route, record, injector)
+      responder.respond(route, subject, injector)
     end
 
     def template_path

--- a/spec/default_route_spec.rb
+++ b/spec/default_route_spec.rb
@@ -5,12 +5,12 @@ require "raptor"
 module RouterTestApp
   module Presenters
     class Post
-      def initialize(record)
-        @record = record
+      def initialize(subject)
+        @subject = subject
       end
 
       def title
-        @record.title.upcase
+        @subject.title.upcase
       end
     end
   end

--- a/spec/injector_spec.rb
+++ b/spec/injector_spec.rb
@@ -7,7 +7,7 @@ describe Raptor::Injector do
   def method_taking_splat(*); 'nothing'; end
   def method_taking_nothing; 'nothing' end
   def method_taking_only_a_block(&block); 'nothing' end
-  def method_taking_record(record); record; end
+  def method_taking_subject(subject); subject; end
 
   let(:injector) do
     Raptor::Injector.new([Raptor::Injectables::Fixed.new(:id, 5)])
@@ -41,11 +41,11 @@ describe Raptor::Injector do
     end.to raise_error(Raptor::UnknownInjectable)
   end
 
-  it "injects records once it's been given one" do
-    record = stub
-    method = method(:method_taking_record)
-    injector_with_record = injector.add_record(record)
-    injector_with_record.call(method).should == record
+  it "injects the subject once it's been given one" do
+    subject = stub
+    method = method(:method_taking_subject)
+    injector_with_subject = injector.add_subject(subject)
+    injector_with_subject.call(method).should == subject
   end
 
   it "injects requests once it's been given one" do


### PR DESCRIPTION
This gets around injecting `record` into `Blog::Presenters::PostList`, and lets us be clearer with terminology (`subject` is what the `delegate` returns). 

It also helps with users thinking all delegates have to return records.
