### PR TITLE
validate delegate names

### DIFF
--- a/lib/raptor/validation.rb
+++ b/lib/raptor/validation.rb
@@ -2,12 +2,21 @@ module Raptor
   class ValidatesRoutes
     def self.validate_route_params!(params)
       raise Raptor::ConflictingRoutes if params[:redirect] && params[:render]
+      if bad_delegate?(params[:to])
+        raise Raptor::BadDelegate.new("#{params[:to]} is not a good delegate name")
+      end
     end
 
     def self.pairs(routes)
       routes.product(routes).select do |x,y|
         x != y
       end
+    end
+
+    def self.bad_delegate?(delegate_name)
+      ['#','.'].select do |method_splitter|
+        delegate_name.include?(method_splitter)
+      end.empty?
     end
 
     def self.same_names?(a,b)
@@ -21,5 +30,6 @@ module Raptor
   end
 
   class ConflictingRoutes < RuntimeError; end
+  class BadDelegate < RuntimeError; end
 end
 

--- a/lib/raptor/validation.rb
+++ b/lib/raptor/validation.rb
@@ -14,6 +14,7 @@ module Raptor
     end
 
     def self.bad_delegate?(delegate_name)
+      return false if delegate_name.nil?
       ['#','.'].select do |method_splitter|
         delegate_name.include?(method_splitter)
       end.empty?

--- a/spec/route_validation_spec.rb
+++ b/spec/route_validation_spec.rb
@@ -3,27 +3,55 @@ require_relative "spec_helper"
 require_relative "../lib/raptor/validation"
 
 describe "route validation" do
+  DEFAULT_GOOD_PARAMS = {:to => 'GoodDelegate.class_method'}
+  def params(params={})
+    DEFAULT_GOOD_PARAMS.merge(params)
+  end
+
   context "the route params" do
     it "rejects routes with both a render and a redirect" do
-      redirect_and_render = {:redirect => :index, :render => :show}
+      redirect_and_render = params(:redirect => :index, :render => :show)
       expect do
         Raptor::ValidatesRoutes.validate_route_params!(redirect_and_render)
       end.to raise_error(Raptor::ConflictingRoutes)
     end
 
     it "does not reject route params with just a redirect" do
-      just_redirect = {:redirect => :index}
+      just_redirect = params(:redirect => :index)
       Raptor::ValidatesRoutes.validate_route_params!(just_redirect)
     end
 
     it "does not reject route params with just a render" do
-      just_render = {:render => :index}
+      just_render = params(:render => :index)
       Raptor::ValidatesRoutes.validate_route_params!(just_render)
     end
 
     it "does not reject empty route params" do
-      empty_params = {}
+      empty_params = params
       Raptor::ValidatesRoutes.validate_route_params!(empty_params)
+    end
+
+    describe 'validating delegate names' do
+      it "rejects routes who only specify a class" do
+        specified_delegate_class = params(:to => 'OnlyClass')
+        expect do
+          Raptor::ValidatesRoutes.validate_route_params!(specified_delegate_class)
+        end.to raise_error(Raptor::BadDelegate, 'OnlyClass is not a good delegate name')
+      end
+
+      it "allows routes that specify a delegate with #" do
+        specified_delegate_class = params(:to => 'GoodDelegate#instance_method')
+        expect do
+          Raptor::ValidatesRoutes.validate_route_params!(specified_delegate_class)
+        end.to_not raise_error(Raptor::BadDelegate)
+      end
+
+      it "allows routes that specify a delegate with ." do
+        specified_delegate_class = params(:to => 'GoodDelegate.class_method')
+        expect do
+          Raptor::ValidatesRoutes.validate_route_params!(specified_delegate_class)
+        end.to_not raise_error(Raptor::BadDelegate)
+      end
     end
   end
 


### PR DESCRIPTION
This gives a nicer error message when you delegate `:to => 'CreatesPosts'
