### PR TITLE
inject env from the request

### DIFF
--- a/lib/raptor/injector.rb
+++ b/lib/raptor/injector.rb
@@ -105,7 +105,7 @@ module Raptor
          :http_method => lambda { @request.request_method },
          :path => lambda { @request.path_info },
          :params => lambda { @request.params },
-         :env => lambda { @request.env }
+         :rack_env => lambda { @request.env }
         }
       end
     end

--- a/lib/raptor/injector.rb
+++ b/lib/raptor/injector.rb
@@ -104,7 +104,8 @@ module Raptor
         {:request => lambda { @request },
          :http_method => lambda { @request.request_method },
          :path => lambda { @request.path_info },
-         :params => lambda { @request.params }
+         :params => lambda { @request.params },
+         :env => lambda { @request.env }
         }
       end
     end

--- a/spec/injectables_spec.rb
+++ b/spec/injectables_spec.rb
@@ -25,8 +25,8 @@ describe Raptor::Injectables::Request do
     subject.sources(injector).fetch(:params).call.should == {"param" => "value"}
   end
 
-  it "injects env" do
-    subject.sources(injector).fetch(:env).call.should == req.env
+  it "injects rack_env from request" do
+    subject.sources(injector).fetch(:rack_env).call.should == req.env
   end
 end
 

--- a/spec/injectables_spec.rb
+++ b/spec/injectables_spec.rb
@@ -24,6 +24,10 @@ describe Raptor::Injectables::Request do
   it "injects request params" do
     subject.sources(injector).fetch(:params).call.should == {"param" => "value"}
   end
+
+  it "injects env" do
+    subject.sources(injector).fetch(:env).call.should == req.env
+  end
 end
 
 describe Raptor::Injectables::RouteVariable do


### PR DESCRIPTION
Various midlewaren pass special stuff through env (for example, Warden uses it to hold the currently authenticated user). Whilst this is also crazy (just like injecting the request), we should still probably do it.
