### PR TITLE
namespace injected request into rack_request

### DIFF
--- a/lib/raptor/injector.rb
+++ b/lib/raptor/injector.rb
@@ -101,7 +101,7 @@ module Raptor
       end
 
       def sources(injector)
-        {:request => lambda { @request },
+        {:rack_request => lambda { @request },
          :http_method => lambda { @request.request_method },
          :path => lambda { @request.path_info },
          :params => lambda { @request.params }

--- a/spec/injectables_spec.rb
+++ b/spec/injectables_spec.rb
@@ -10,7 +10,7 @@ describe Raptor::Injectables::Request do
   subject { Raptor::Injectables::Request.new(req) }
 
   it "injects the whole request" do
-    subject.sources(injector).fetch(:request).call.should == req
+    subject.sources(injector).fetch(:rack_request).call.should == req
   end
 
   it "injects the HTTP method" do


### PR DESCRIPTION
This is to stop naming conflicts if the user has some custom `Request` model inside their app. It also makes it obvious that they are directly coupling to rack in their delegate, which we want.
