### PR TITLE
don't override default values for parameters

### DIFF
--- a/lib/raptor/injector.rb
+++ b/lib/raptor/injector.rb
@@ -23,8 +23,11 @@ module Raptor
 
     def args(method)
       method = injection_method(method)
+
       parameters(method).select do |type, name|
         name && type != :rest && type != :block
+      end.reject do |type, name|
+        type == :opt && sources[name].nil?
       end.map do |type, name|
         source_proc = sources[name] or raise UnknownInjectable.new(name)
         source_proc.call

--- a/spec/injector_spec.rb
+++ b/spec/injector_spec.rb
@@ -9,7 +9,7 @@ describe Raptor::Injector do
   def method_taking_only_a_block(&block); 'nothing' end
   def method_taking_subject(subject); subject; end
   def method_taking_optional_id(id = 0); id; end
-  def method_taking_optional_arg(arg = 0); arg; end
+  def method_taking_optional_arg(uninjectable_optional_arg = 0); uninjectable_optional_arg; end
 
   let(:injector) do
     Raptor::Injector.new([Raptor::Injectables::Fixed.new(:id, 5)])

--- a/spec/injector_spec.rb
+++ b/spec/injector_spec.rb
@@ -8,6 +8,8 @@ describe Raptor::Injector do
   def method_taking_nothing; 'nothing' end
   def method_taking_only_a_block(&block); 'nothing' end
   def method_taking_subject(subject); subject; end
+  def method_taking_optional_id(id = 0); id; end
+  def method_taking_optional_arg(arg = 0); arg; end
 
   let(:injector) do
     Raptor::Injector.new([Raptor::Injectables::Fixed.new(:id, 5)])
@@ -27,6 +29,14 @@ describe Raptor::Injector do
 
   it "injects [] when the method takes only a block" do
     injector.call(method(:method_taking_only_a_block)).should == 'nothing'
+  end
+
+  it "injects required arguments even if they are optional" do
+    injector.call(method(:method_taking_optional_id)).should == 5
+  end
+
+  it "uses the default value if the argument was optional and nothing was passed for it" do
+    injector.call(method(:method_taking_optional_arg)).should == 0
   end
 
   it "injects arguments from initialize for the new method" do


### PR DESCRIPTION
If an argument to a method has a default argument and the injector doesn't have a value for that argument. It should use the default value instead of throwing an exception.

e.g.

Datamapper's all method

```
def all(query = Undefined)
  if query.equal?(Undefined) || (query.kind_of?(Hash) && query.empty?)
    # TODO: after adding Enumerable methods to Model, try to return self here
    new_collection(self.query.dup)
  else
    new_collection(scoped_query(query))
  end 
end
```
