### PR TITLE
Shouldn't tilt be a dependency?

### DIFF
--- a/raptor.gemspec
+++ b/raptor.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rspec"
   s.add_dependency "rack"
+  s.add_dependency "tilt"
 
   s.require_path = "lib"
   s.required_rubygems_version = ">= 1.3.6"


### PR DESCRIPTION
I was wondering that because I was playing with raptor, and I got the following error when starting a very simple "hello world"-kinda app:

```
/Users/bernardes/.rvm/gems/ruby-1.9.3-p0@rails32/bundler/gems/raptor-4bed05d51f57/lib/raptor/templates.rb:1:in `require': cannot load such file -- tilt (LoadError)
```

My Gemfile was:

``` ruby
gem 'raptor', :git => 'git@github.com:garybernhardt/raptor.git'
```

And my whole app (app.rb) was:

``` ruby
require 'raptor'

module Blog
  Routes = Raptor.routes(self) do
    root :render => 'root', :present => :root
  end

  module Presenters
    class Root
    end
  end

  App = Raptor::App.new(self)
end
```

The updated gemspec is attached, in case you want to use it :)
