### PR TITLE
update readme to not call Raptor.routes anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Raptor is an experimental web framework that encourages simple, decoupled object
 
 ```ruby
 module MyApp
-  Routes = Raptor.routes(self) do
+  App = Raptor::App.new(self) do
     path "article" do
       show
       index


### PR DESCRIPTION
The example app in the readme was still calling Raptor.routes.
