### PR TITLE
kill the vestigial remenants of record terminology

### DIFF
--- a/lib/raptor/delegation.rb
+++ b/lib/raptor/delegation.rb
@@ -31,9 +31,9 @@ module Raptor
     def delegate(injector)
       return nil if @delegate_path.nil?
       Raptor.log("Delegating to #{@delegate_path.inspect}")
-      record = injector.call(delegate_method)
-      Raptor.log("Delegate returned #{record.inspect}")
-      record
+      subject = injector.call(delegate_method)
+      Raptor.log("Delegate returned #{subject.inspect}")
+      subject
     end
 
     def delegate_method

--- a/lib/raptor/router.rb
+++ b/lib/raptor/router.rb
@@ -249,8 +249,8 @@ module Raptor
     def respond_to_request(injector, request)
       Raptor.log("Routing #{request.path_info.inspect} to #{path.inspect}")
       injector = injector.add_route_path(request, @path)
-      record = @delegator.delegate(injector)
-      @responder.respond(self, record, injector)
+      subject = @delegator.delegate(injector)
+      @responder.respond(self, subject, injector)
     end
 
     def action_for_exception(e)

--- a/spec/responders_spec.rb
+++ b/spec/responders_spec.rb
@@ -36,14 +36,14 @@ describe Raptor::ActionTemplateResponder do
   it "renders templates" do
     app = stub(:presenters => {"Post" => PostPresenter})
     responder = Raptor::ActionTemplateResponder.new(app, 'post', 'posts', :show)
-    record = stub
+    subject = stub
     route = stub
     injector = Raptor::Injector.new([])
     Raptor::Template.stub(:from_path).with(PostPresenter.new, "posts/show.html.erb")
     layout = stub(:layout)
     layout.stub(:render) { "it worked" }
     Raptor::FindsLayouts.stub(:find).with('posts') { layout }
-    response = responder.respond(route, record, injector)
+    response = responder.respond(route, subject, injector)
     response.body.join.strip.should == "it worked"
   end
 end

--- a/spec/route_spec.rb
+++ b/spec/route_spec.rb
@@ -17,7 +17,6 @@ describe Raptor::Route do
   it "routes to nested routes"
   it "stores templates in templates directory, not views"
   it "allows overriding of the presenter class"
-  it "uses consistent degelate terminology instead of sometimes calling them records"
   it "doesn't require .html.erb on template names"
   it "includes type definitions in routes so they can be casted before injection"
 end


### PR DESCRIPTION
I've killed the last couple of places where we referred to records instead of subjects (I think). Removed a pending spec for it as well.
