### PR TITLE
Alternate delegation syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The `update` route in the above example uses the default update behavior we know
 In addition, if `find_and_update` raised `Raptor::ValidationError`, it would've redirected to `:edit`. If a template had been rendered, it would've gone through `MyApp::Presenters::Article`. The full expansion of the update route is:
 
     route :update, "PUT", "article/:id",
-      :to => "MyApp::Records::Article.find_and_update",
+      to => MyApp::Records::Article, :with => :find_and_update,
       :redirect => :show, ValidationError => :edit`
 
 All of the standard Raptor routes are syntactic sugar for these longer forms.

--- a/lib/raptor.rb
+++ b/lib/raptor.rb
@@ -32,6 +32,10 @@ module Raptor
       ]
     end
 
+    def const_get(name)
+      @app_module.const_get(name)
+    end
+
     def injectables
       return [] unless @app_module.const_defined?(:Injectables)
       injectables = @app_module::Injectables

--- a/lib/raptor/delegation.rb
+++ b/lib/raptor/delegation.rb
@@ -1,43 +1,20 @@
 module Raptor
-  class DelegateFinder
-    def initialize(starting_module, delegate_name)
-      @starting_module = starting_module
-      @module_path, @method_name = delegate_name.split('.')
-    end
-
-    def find
-      target_module.method(@method_name)
-    end
-
-    def target_module
-      the_module = @starting_module
-      module_path_components.each do |module_name|
-        the_module = the_module.const_get(module_name)
-      end
-      the_module
-    end
-
-    def module_path_components
-      @module_path.split('::')
-    end
-  end
-
   class Delegator
-    def initialize(app, delegate_path)
-      @app = app
-      @delegate_path = delegate_path
+    def initialize(delegate, method_name)
+      @delegate = delegate
+      @method_name = method_name
     end
 
     def delegate(injector)
-      return nil if @delegate_path.nil?
-      Raptor.log("Delegating to #{@delegate_path.inspect}")
+      return nil unless @delegate && @method_name
+      Raptor.log("Delegating to #{@delegate.inspect} with #{@method_name.inspect}")
       record = injector.call(delegate_method)
       Raptor.log("Delegate returned #{record.inspect}")
       record
     end
 
     def delegate_method
-      @app.find_method(@delegate_path)
+      @delegate.method(@method_name)
     end
   end
 end

--- a/lib/raptor/router.rb
+++ b/lib/raptor/router.rb
@@ -111,6 +111,8 @@ module Raptor
     end
   end
 
+  class BadRouteSyntax < RuntimeError; end
+
   class BuildsRoutes
     include StandardRoutes
 
@@ -160,6 +162,8 @@ module Raptor
       when 3
         {:to => params[0],
           :with => params[1]}.merge(params.last)
+      else
+        raise BadRouteSyntax.new("You gave more than three arguments to a route: #{params.inspect}, which is invalid syntax")
       end
     end
 

--- a/lib/raptor/router.rb
+++ b/lib/raptor/router.rb
@@ -43,63 +43,71 @@ module Raptor
   end
 
   module StandardRoutes
-    def root(params={})
-      route(:root, "GET", "/", params)
+    def root(*params)
+      options = options(params)
+      route(:root, "GET", "/", options)
     end
 
-    def show(params={})
+    def show(*params)
+      options = options(params)
       route(:show, "GET", "/:id",
             {:present => default_single_presenter,
-              :to => delegate(params),
-              :with => :find_by_id}.merge(params))
+              :to => delegate(options),
+              :with => :find_by_id}.merge(options))
     end
 
-    def new(params={})
+    def new(*params)
+      options = options(params)
       route(:new, "GET", "/new",
             {:present => default_single_presenter,
-              :to => delegate(params),
-             :with => :new}.merge(params))
+              :to => delegate(options),
+             :with => :new}.merge(options))
     end
 
-    def index(params={})
+    def index(*params)
+      options = options(params)
       route(:index, "GET", "/",
             {:present => default_list_presenter,
-              :to => delegate(params),
-              :with => :all}.merge(params))
+              :to => delegate(options),
+              :with => :all}.merge(options))
     end
 
-    def create(params={})
+    def create(*params)
+      options = options(params)
       route(:create, "POST", "/",
             {:redirect => :show,
              ValidationError => :new,
-              :to => delegate(params),
-              :with => :create}.merge(params))
+              :to => delegate(options),
+              :with => :create}.merge(options))
     end
 
-    def edit(params={})
+    def edit(*params)
+      options = options(params)
       route(:edit, "GET", "/:id/edit",
             {:present => default_single_presenter,
-              :to => delegate(params),
-              :with => :find_by_id}.merge(params))
+              :to => delegate(options),
+              :with => :find_by_id}.merge(options))
     end
 
-    def update(params={})
+    def update(*params)
+      options = options(params)
       route(:update, "PUT", "/:id",
             {:redirect => :show,
              ValidationError => :edit,
-              :to => delegate(params),
-              :with => :find_and_update}.merge(params))
+              :to => delegate(options),
+              :with => :find_and_update}.merge(options))
     end
 
-    def destroy(params={})
+    def destroy(*params)
+      options = options(params)
       route(:destroy, "DELETE", "/:id",
             {:redirect => :index,
-              :to => delegate(params),
-              :with => :destroy}.merge(params))
+              :to => delegate(options),
+              :with => :destroy}.merge(options))
     end
 
-    def delegate(params)
-      params[:to] || record_module
+    def delegate(options)
+      options[:to] || record_module
     end
   end
 
@@ -140,13 +148,29 @@ module Raptor
       @app.const_get(:Records).const_get(records_name)
     end
 
-    def route(action, http_method, path, params={})
+    def options(params)
+      case params.length
+      when 0
+        {}
+      when 1
+        params.last
+      when 2
+        {:to => params[0],
+          :with => params[1]}
+      when 3
+        {:to => params[0],
+          :with => params[1]}.merge(params.last)
+      end
+    end
+
+    def route(action, http_method, path, *params)
+      options = options(params)
       path = @parent_path + path
-      Raptor::ValidatesRoutes.validate_route_params!(params)
-      params = params.merge(:action => action,
+      Raptor::ValidatesRoutes.validate_route_params!(options)
+      options = options.merge(:action => action,
                             :http_method => http_method,
                             :path => path)
-      route = Route.for_app(@app, @parent_path, params)
+      route = Route.for_app(@app, @parent_path, options)
       @routes << route
       route
     end

--- a/lib/raptor/validation.rb
+++ b/lib/raptor/validation.rb
@@ -2,32 +2,7 @@ module Raptor
   class ValidatesRoutes
     def self.validate_route_params!(params)
       raise Raptor::ConflictingRoutes if params[:redirect] && params[:render]
-      if bad_delegate?(params[:to])
-        raise Raptor::BadDelegate.new("#{params[:to]} is not a good delegate name")
-      end
     end
-
-    def self.pairs(routes)
-      routes.product(routes).select do |x,y|
-        x != y
-      end
-    end
-
-    def self.bad_delegate?(delegate_name)
-      return false if delegate_name.nil?
-      ['#','.'].select do |method_splitter|
-        delegate_name.include?(method_splitter)
-      end.empty?
-    end
-
-    def self.same_names?(a,b)
-      a.name == b.name
-    end
-
-    def self.same_redirects?(a,b)
-      a.redirects == b.redirects
-    end
-
   end
 
   class ConflictingRoutes < RuntimeError; end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -7,7 +7,7 @@ describe Raptor::App, "integrated" do
     module AwesomeSite
       App = Raptor::App.new(self) do
         path 'post' do
-          index :to => Object, :with => :new
+          index Object, :new
         end
       end
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -7,7 +7,7 @@ describe Raptor::App, "integrated" do
     module AwesomeSite
       App = Raptor::App.new(self) do
         path 'post' do
-          index :to => "Object.new"
+          index :to => Object, :with => :new
         end
       end
 

--- a/spec/default_route_spec.rb
+++ b/spec/default_route_spec.rb
@@ -41,12 +41,14 @@ module RouterTestApp
 
   App = Raptor::App.new(self) do
     path "post" do
-      new; show; index; create; edit; update; destroy
+      new;show;index;create;edit;update;destroy
     end
     path "post_with_redirect" do
-      new :to => "RouterTestApp::Records::Post.new",
+      new :to => RouterTestApp::Records::Post,
+        :with => :new,
         :redirect => :index
-      index
+      index :to => RouterTestApp::Records::Post,
+        :with => :new
     end
   end
 end

--- a/spec/default_route_spec.rb
+++ b/spec/default_route_spec.rb
@@ -44,11 +44,11 @@ module RouterTestApp
       new;show;index;create;edit;update;destroy
     end
     path "post_with_redirect" do
-      new :to => RouterTestApp::Records::Post,
-        :with => :new,
+      new RouterTestApp::Records::Post,
+        :new,
         :redirect => :index
-      index :to => RouterTestApp::Records::Post,
-        :with => :new
+      index RouterTestApp::Records::Post,
+        :new
     end
   end
 end

--- a/spec/delegation_spec.rb
+++ b/spec/delegation_spec.rb
@@ -2,36 +2,21 @@ require "rack"
 require_relative "spec_helper"
 require_relative "../lib/raptor"
 
-describe Raptor::DelegateFinder do
-  module AModule
-    module Child
-      def self.a_method
-      end
-    end
-  end
-
-  it "finds constants in the module" do
-    method = Raptor::DelegateFinder.new(AModule, "Child.a_method").find
-    method.should == AModule::Child.method(:a_method)
-  end
-
-  it "finds constants not in the module" do
-    method = Raptor::DelegateFinder.new(AModule, "Object.new").find
-    method.should == Object.method(:new)
-  end
-end
-
 describe Raptor::Delegator do
+  let(:injector) { Raptor::Injector.new([]) }
+
   it "returns nil if the delegate is nil" do
-    injector = Raptor::Injector.new([])
-    delegator = Raptor::Delegator.new(AModule, nil)
+    delegator = Raptor::Delegator.new(nil, :new)
+    delegator.delegate(injector).should be_nil
+  end
+
+  it "returns nil if the method is nil" do
+    delegator = Raptor::Delegator.new('not nil', nil)
     delegator.delegate(injector).should be_nil
   end
 
   it "calls the named method" do
-    app = Raptor::App.new(Object) {}
-    delegator = Raptor::Delegator.new(app, "Hash.new")
-    injector = Raptor::Injector.new([])
+    delegator = Raptor::Delegator.new(Hash, :new)
     delegator.delegate(injector).should == {}
   end
 end

--- a/spec/route_builder_spec.rb
+++ b/spec/route_builder_spec.rb
@@ -1,8 +1,8 @@
 require "raptor"
 
 describe Raptor::BuildsRoutes do
+  let(:app) { stub(:app) }
   it "errors when asked to create guess a presenter for a root URL like GET /" do
-    app = stub(:app)
     expect do
       Raptor::BuildsRoutes.new(app).index
     end.to raise_error(Raptor::CantInferModulePathsForRootRoutes)

--- a/spec/route_builder_spec.rb
+++ b/spec/route_builder_spec.rb
@@ -7,5 +7,11 @@ describe Raptor::BuildsRoutes do
       Raptor::BuildsRoutes.new(app).index
     end.to raise_error(Raptor::CantInferModulePathsForRootRoutes)
   end
+
+  it "errors if you give it too many arguments" do
+    expect do
+      Raptor::BuildsRoutes.new(app).index(1,2,3,4)
+    end.to raise_error(Raptor::BadRouteSyntax)
+  end
 end
 

--- a/spec/route_validation_spec.rb
+++ b/spec/route_validation_spec.rb
@@ -30,29 +30,6 @@ describe "route validation" do
       empty_params = params
       Raptor::ValidatesRoutes.validate_route_params!(empty_params)
     end
-
-    describe 'validating delegate names' do
-      it "rejects routes who only specify a class" do
-        specified_delegate_class = params(:to => 'OnlyClass')
-        expect do
-          Raptor::ValidatesRoutes.validate_route_params!(specified_delegate_class)
-        end.to raise_error(Raptor::BadDelegate, 'OnlyClass is not a good delegate name')
-      end
-
-      it "allows routes that specify a delegate with #" do
-        specified_delegate_class = params(:to => 'GoodDelegate#instance_method')
-        expect do
-          Raptor::ValidatesRoutes.validate_route_params!(specified_delegate_class)
-        end.to_not raise_error(Raptor::BadDelegate)
-      end
-
-      it "allows routes that specify a delegate with ." do
-        specified_delegate_class = params(:to => 'GoodDelegate.class_method')
-        expect do
-          Raptor::ValidatesRoutes.validate_route_params!(specified_delegate_class)
-        end.to_not raise_error(Raptor::BadDelegate)
-      end
-    end
   end
 
   it "gives a reasonable error if there's no presenter in the params"


### PR DESCRIPTION
This introduces new delegation syntax in the router, which looks somewhat like this:

```
Routes = Raptor::App.new(self) do
    path "post" do
    create Records::Post, :create!
 end
```

There are several advantages to this syntax:

1) The user can explicitly inject into delegates:

```
Routes = Raptor::App.new(self) do
  queue = #... some sort of persistent queue initialized here
  crawler = WebCrawler.new(queue)

  path "to-be-crawled" do
    create crawler, :enqueue!, :require => :logged_in
  end
end
```

This is the big advantage from my point of view. I want to be able to inject dependencies at startup time, rather than having to write an injector that statically injects an instance of an object.

2) We no longer use strings for describing delegates, instead  giving an object and method name

```
create Records::Posts, :new
```

is better (imo) than

```
create :to => 'Records::Posts.new'
```

3) The syntax is more 'Rubyish'

Instead of specifying classes/objects with strings, we specify them with objects and method names.
## Downsides:

a)
When using class methods: the class _has_ to be declared before the router declaration, e.g. the following throws errors:

```
Routes = Raptor::App.new(self) do
    path "post" do
    create Records::Post, :create!
 end

 class Records::Post #first declaration of this class
 end
```

I don't think this is a big issue in practice though, when I was building an app all my records/etc were declared in other files that were required at the start of the Raptor::App file. Might be an issue for small apps though.

b)
I'm somewhat unsure if this is a good idea, even if just because of how icky the implementation is (check out https://github.com/tcrayford/raptor/commit/9cb533cb84a15094d96432d01c1e3e1ddf7c5451#L1R152 !).

The syntax is also _slightly_ less terse than our current syntax, but I don't think that's much of an issue from my PoV.

c)
You can't inject instance methods and have raptor instantiate the required object (there's probably some cleanup required to remove this if this goes in).
