### PR TITLE
Content for

### DIFF
--- a/lib/raptor/templates.rb
+++ b/lib/raptor/templates.rb
@@ -42,15 +42,15 @@ module Raptor
   class ViewContext
     def initialize(presenter)
       @presenter = presenter
-      @content_areas = {}
+      @content_areas = Hash.new([])
     end
 
     def content_for(name, &block)
-      @content_areas[name] = block[]
+      @content_areas[name] << block[]
     end
 
     def yield_content_for(name)
-      @content_areas[name]
+      @content_areas[name].join
     end
 
     def method_missing(message, *args, &block)

--- a/spec/fixtures/content_for_head.html.erb
+++ b/spec/fixtures/content_for_head.html.erb
@@ -1,0 +1,1 @@
+<%= yield_content_for :head %>

--- a/spec/fixtures/view_with_content_for.html.erb
+++ b/spec/fixtures/view_with_content_for.html.erb
@@ -1,0 +1,3 @@
+<% content_for :head do %>
+  <script></script>
+<% end %>

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -65,6 +65,13 @@ describe Raptor::ViewContext do
     end
     context.yield_content_for(:head).should == "what"
   end
+
+  it "can store many content_for under the same key" do
+    context = Raptor::ViewContext.new(stub)
+    context.content_for(:head) { "what" }
+    context.content_for(:head) { "what" }
+    context.yield_content_for(:head).should == "whatwhat"
+  end
 end
 
 describe Raptor::FindsLayouts do

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -8,7 +8,7 @@ describe Raptor::Template do
     expect do
       Raptor::Template.from_path(presenter, "with_undefined_method_call_in_index/index.html.erb").render
     end.to raise_error(NameError,
-                       /undefined local variable or method `undefined_method'/)
+                       /undefined method `undefined_method'/)
   end
 
   it "renders the template" do
@@ -27,11 +27,43 @@ describe Raptor::Template do
 end
 
 describe Raptor::Layout do
+  let(:inner) { stub(:render => 'inner', :presenter => nil) }
+
   it "renders a yielded template" do
-    inner = stub(:render => 'inner')
     rendered = Raptor::Layout.new('spec/fixtures/layout.html.erb').
       render(inner)
     rendered.strip.should == "<div>inner</div>"
+  end
+
+  it "can use content_for in the inner layout" do
+    with_content = stub(:yield_content_for => "<script></script>")
+    inner.stub(:presenter => with_content)
+    rendered = Raptor::Layout.new('spec/fixtures/content_for_head.html.erb').
+      render(inner)
+    rendered.strip.should == "<script></script>"
+  end
+
+  it "integrated content_for" do
+    with_content = Raptor::ViewContext.new(stub)
+    inner = Raptor::Template.from_path(with_content, "../spec/fixtures/view_with_content_for.html.erb")
+    rendered = Raptor::Layout.new('spec/fixtures/content_for_head.html.erb').
+      render(inner)
+    rendered.strip.should == "<script></script>"
+  end
+end
+
+describe Raptor::ViewContext do
+  it "delegates to the presenter" do
+    presenter = stub(:opens_doors? => false)
+    Raptor::ViewContext.new(presenter).opens_doors?.should be_false
+  end
+
+  it "stores and yields content_for" do
+    context = Raptor::ViewContext.new(stub)
+    context.content_for :head do
+      "what"
+    end
+    context.yield_content_for(:head).should == "what"
   end
 end
 


### PR DESCRIPTION
This adds `content_for` and `yield_content_for`.

I thought about adding a `NoContentForError` for when users call `yield_content_for` with a name without content in it. However, this seemed like it was going to be annoying. This sort of contradicts with how I usually think about design (raise errors instead of doing nothing silently), but it fits with how content_for is used most of the time in practice (to set <title> and other tags in the <head>).
