### PR TITLE
add content_for

### DIFF
--- a/lib/raptor/templates.rb
+++ b/lib/raptor/templates.rb
@@ -34,7 +34,29 @@ module Raptor
     end
 
     def render(inner, presenter)
-      Tilt.new(@path).render { inner.render(presenter) }
+      context = ViewContext.new(presenter)
+      rendered = inner.render(context)
+      Tilt.new(@path).render(context) { rendered }
+    end
+  end
+
+  class ViewContext < BasicObject
+    def initialize(presenter)
+      @presenter = presenter
+      @areas = {}
+    end
+
+    def content_for(name, &block)
+      if block
+        @areas[name] ||= []
+        @areas[name] << block.call 
+      else
+        @areas[name].join
+      end
+    end
+
+    def method_missing(name, *args, &block)
+      @presenter.send(name, *args, &block)
     end
   end
 

--- a/spec/fixtures/layout_with_content_for.html.erb
+++ b/spec/fixtures/layout_with_content_for.html.erb
@@ -1,0 +1,1 @@
+<%= content_for :head %>

--- a/spec/fixtures/provides_content_for.html.erb
+++ b/spec/fixtures/provides_content_for.html.erb
@@ -1,0 +1,3 @@
+<% content_for :head do %>
+  <script></script>
+<% end %>

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -25,12 +25,38 @@ describe Raptor::Template do
 end
 
 describe Raptor::Layout do
+  let(:presenter) { stub }
   it "renders a yielded template" do
     inner = stub(:render => 'inner')
-    presenter = stub
     rendered = Raptor::Layout.new('spec/fixtures/layout.html.erb').
       render(inner, presenter)
     rendered.strip.should == "<div>inner</div>"
+  end
+
+  it "integrates content_for" do
+    inner = Raptor::Template.from_path("../spec/fixtures/provides_content_for.html.erb")
+    layout = Raptor::Layout.new('spec/fixtures/layout_with_content_for.html.erb')
+    rendered = layout.render(inner, presenter)
+    rendered.strip.should include("<script></script")
+  end
+end
+
+describe Raptor::ViewContext do
+  it "delegates to the presenter" do
+    Raptor::ViewContext.new(stub(:cheese => 'walrus')).cheese.should == 'walrus'
+  end
+
+  it "stores content_for" do
+    context = Raptor::ViewContext.new(stub)
+    context.content_for(:head) { 'what' }
+    context.content_for(:head).should == 'what'
+  end
+
+  it "appends multiple content_for blocks" do
+    context = Raptor::ViewContext.new(stub)
+    context.content_for(:head) { 'what' }
+    context.content_for(:head) { 'what' }
+    context.content_for(:head).should == 'whatwhat'
   end
 end
 


### PR DESCRIPTION
Uses one method `content_for`, with and without a block to yield and record content.
