### PR TITLE
Fix custom constraints

### DIFF
--- a/lib/raptor.rb
+++ b/lib/raptor.rb
@@ -43,9 +43,20 @@ module Raptor
     def find_method(method_path)
       DelegateFinder.new(@app_module, method_path).find
     end
+
+    def constraint_named(name)
+      raise NoSuchConstraint.new(name) unless constraint_exists?(name)
+      @app_module::Constraints.const_get(name)
+    end
+
+    def constraint_exists?(name)
+      @app_module.const_defined?(:Constraints) &&
+        @app_module::Constraints.const_defined?(name)
+    end
   end
 
   class ValidationError < RuntimeError; end
+  class NoSuchConstraint < RuntimeError; end
 
   module Util
     def self.underscore(string)

--- a/lib/raptor/injector.rb
+++ b/lib/raptor/injector.rb
@@ -12,7 +12,7 @@ module Raptor
       # Merge all injectables' sources into a single hash
       @sources ||= @injectables.map do |injectable|
         injectable.sources(self)
-      end.inject(&:merge)
+      end.inject({}, &:merge)
     end
 
     def call(method)

--- a/lib/raptor/router.rb
+++ b/lib/raptor/router.rb
@@ -260,6 +260,7 @@ module Raptor
     end
 
     def match?(injector, request)
+      injector = injector.add_route_path(request, @path)
       @constraints.all? do |constraint|
         injector.call(constraint.method(:match?))
       end

--- a/lib/raptor/router.rb
+++ b/lib/raptor/router.rb
@@ -202,13 +202,13 @@ module Raptor
   end
 
   class Constraints
-    def initialize(app_module)
-      @app_module = app_module
+    def initialize(app)
+      @app = app
     end
 
     def matching(name)
-      constraint = @app_module::Constraints.const_get(Util.camel_case(name))
-      [constraint]
+      constraint = @app.constraint_named(Util.camel_case(name))
+      [constraint.new]
     end
   end
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -61,6 +61,11 @@ describe Raptor::App, "app wrapping" do
         end
       end
 
+      module Constraints
+        class Never
+        end
+      end
+
       App = Raptor::App.new(self) do
       end
     end
@@ -97,6 +102,20 @@ describe Raptor::App, "app wrapping" do
     it "lists nothing when the app has no injectables module" do
       app = EmptySite::App
       app.injectables.should == []
+    end
+  end
+
+  describe "#constraint_named" do
+    it "has the named constraint" do
+      app = AwesomeSite::App
+      app.constraint_named(:Never).should == AwesomeSite::Constraints::Never
+    end
+
+    it "warns of missing constraints" do
+      app = EmptySite::App
+      expect do
+        app.constraint_named(:DoesNotExist)
+      end.to raise_error(Raptor::NoSuchConstraint)
     end
   end
 end

--- a/spec/injector_spec.rb
+++ b/spec/injector_spec.rb
@@ -51,6 +51,13 @@ describe Raptor::Injector do
     end.to raise_error(Raptor::UnknownInjectable)
   end
 
+  it "throws an sane error when given no injectables" do
+    klass = Class.new { def f(unknown_argument); end }
+    expect do
+      Raptor::Injector.new.call(klass.new.method(:f))
+    end.to raise_error(Raptor::UnknownInjectable)
+  end
+
   it "injects the subject once it's been given one" do
     subject = stub
     method = method(:method_taking_subject)

--- a/spec/route_spec.rb
+++ b/spec/route_spec.rb
@@ -3,15 +3,28 @@ require "spec_helper"
 require "raptor"
 
 describe Raptor::Route do
+  let(:injector) { Raptor::Injector.new }
+
   it "errors if redirect target doesn't exist"
 
   it "can render text" do
     app = Raptor::App.new(Object) {}
-    injector = Raptor::Injector.new
     route = Raptor::BuildsRoutes.new(app).root(:text => "the text")
     req = request("GET", "/posts")
     response = route.respond_to_request(injector, req)
     response.body.join.strip.should == "the text"
+  end
+
+  class OnlyIDOfFive
+    def match?(id)
+      id == '5'
+    end
+  end
+
+  it "injects route params into the presenter" do
+    route = Raptor::Route.new(:show, '/posts/:id', [OnlyIDOfFive.new], stub, stub, stub)
+    req = request("GET", "/posts/5")
+    route.match?(injector, req).should be_true
   end
 
   it "routes to nested routes"


### PR DESCRIPTION
This fixes a couple of disparate bugs that were preventing custom constraints from working as they should:
- `Constraints` was being passed in a `Raptor::App` and doing a `const_get` on it.
- Routes weren't injecting path params (like `:id`) when calling `match?`
