### PR TITLE
Add exception to injector on error redirects

### DIFF
--- a/lib/raptor/injector.rb
+++ b/lib/raptor/injector.rb
@@ -61,6 +61,11 @@ module Raptor
                                                                    route_path)]
       Injector.new(injectables)
     end
+
+    def add_exception(e)
+      injectables = @injectables + [Injectables::Fixed.new(:exception, e)]
+      Injector.new(injectables)
+    end
   end
 
   class UnknownInjectable < RuntimeError

--- a/lib/raptor/router.rb
+++ b/lib/raptor/router.rb
@@ -27,6 +27,7 @@ module Raptor
         route.respond_to_request(injector, request)
       rescue Exception => e
         Raptor.log("Looking for a redirect for #{e.inspect}")
+        injector = injector.add_exception(e)
         action = route.action_for_exception(e) or raise
         route_named(action).respond_to_request(injector, request)
       end

--- a/spec/injector_spec.rb
+++ b/spec/injector_spec.rb
@@ -80,6 +80,14 @@ describe Raptor::Injector do
     injector_with_route_path.call(method).should == "5"
   end
 
+  it "injects an exception after being given an exception" do
+    def method_taking_exception(exception); exception; end
+    e = RuntimeError.new
+    method = method(:method_taking_exception)
+    injector_with_exception = injector.add_exception(e)
+    injector_with_exception.call(method).should == e
+  end
+
   context "custom injectables" do
     before do
       module WithInjectables


### PR DESCRIPTION
As per my comments in #57, this makes the exception thrown available when redirecting to a different action when exception handling.
